### PR TITLE
GtkRadioToolButtons for pen size tools

### DIFF
--- a/mainwindow.glade
+++ b/mainwindow.glade
@@ -494,12 +494,4 @@
       </packing>
     </child>
   </object>
-  <object class="GtkRadioToolButton" id="radiotoolbutton1">
-    <property name="use_action_appearance">False</property>
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="use_action_appearance">False</property>
-    <property name="label" translatable="yes">toolbutton</property>
-    <property name="active">True</property>
-  </object>
 </interface>


### PR DESCRIPTION
Changed GtkToolButtons to GtkRadioToolButtons for pen size tools.
